### PR TITLE
Add ability to not use active model validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ form. Attributes can also be defined on use case classes.
 
 ```ruby
 class SignUpForm
-  include UseCase::Params
+  include UseCase.params
   param_key 'sign_up'
 
   attribute :username, String
@@ -50,7 +50,7 @@ The use case interacts with the rest of your application to complete the use cas
 
 ```ruby
 class SignUp
-  include UseCase
+  include UseCase.use_case
 
   def initialize(form)
     @form = form

--- a/lib/use_case.rb
+++ b/lib/use_case.rb
@@ -2,6 +2,7 @@ require "active_model"
 require "wisper"
 
 require "use_case/version"
+require "use_case/module_customiser"
 require "use_case/validation_helpers"
 require "use_case/params"
 
@@ -15,8 +16,54 @@ module UseCase
     base.class_eval do
       prepend Perform
       extend ClassMethods
+      include InstanceMethods
       include Params
+      include ActiveModel::Validations
       include Wisper::Publisher
+    end
+  end
+
+  # Includes a customised use case module.
+  #
+  # @param options [Hash]
+  # @option options [TrueClass,FalseClass] :validations
+  #
+  # @example
+  #   include UseCase.use_case(validations: false)
+  #
+  # @return [Module]
+  # @since 0.0.1
+  def self.use_case(options = {})
+    validations = options.fetch(:validations, true)
+    ModuleCustomiser.new do
+      prepend Perform
+      extend ClassMethods
+      include InstanceMethods
+      include Params
+      if validations
+        include ActiveModel::Validations
+      end
+      include Wisper::Publisher
+    end
+  end
+
+  # Includes a customised params module.
+  #
+  # @param options [Hash]
+  # @option options [TrueClass,FalseClass] :validations
+  #
+  # @example
+  #   include UseCase.params(validations: false)
+  #
+  # @return [Module]
+  # @since 0.0.1
+  def self.params(options = {})
+    validations = options.fetch(:validations, true)
+    ModuleCustomiser.new do
+      include Params
+      if validations
+        include ActiveModel::Validations
+      end
     end
   end
 
@@ -58,120 +105,122 @@ module UseCase
     end
   end
 
-  # Indicates if the use case was successful
-  #
-  # @return [TrueClass, FalseClass]
-  #
-  # @since 0.0.1
-  # @api public
-  def success?
-    !failed?
-  end
+  module InstanceMethods
+    # Indicates if the use case was successful
+    #
+    # @return [TrueClass, FalseClass]
+    #
+    # @since 0.0.1
+    # @api public
+    def success?
+      !failed?
+    end
 
-  # Indicates whether the use case failed
-  #
-  # @return [TrueClass, FalseClass]
-  #
-  # @since 0.0.1
-  # @api public
-  def failed?
-    !!@failed
-  end
+    # Indicates whether the use case failed
+    #
+    # @return [TrueClass, FalseClass]
+    #
+    # @since 0.0.1
+    # @api public
+    def failed?
+      !!@failed
+    end
 
-  # Attach a success callback using wisper
-  #
-  # @see Wisper
-  #
-  # @example
-  #   use_case = SignUp.new(params)
-  #   use_case.on_success do
-  #     # handle success
-  #   end
-  #   use_case.perform
-  #
-  # @since 0.0.1
-  # @api public
-  def on_success(&block)
-    on(namespaced_name(:success), &block)
-  end
+    # Attach a success callback using wisper
+    #
+    # @see Wisper
+    #
+    # @example
+    #   use_case = SignUp.new(params)
+    #   use_case.on_success do
+    #     # handle success
+    #   end
+    #   use_case.perform
+    #
+    # @since 0.0.1
+    # @api public
+    def on_success(&block)
+      on(namespaced_name(:success), &block)
+    end
 
-  # Attach a failure callback
-  #
-  # @see Wisper
-  #
-  # @example
-  #   use_case = SignUp.new(params)
-  #   use_case.on_failure do
-  #     # handle failure
-  #   end
-  #   use_case.perform
-  #
-  # @since 0.0.1
-  # @api public
-  def on_failure(&block)
-    on(namespaced_name(:failure), &block)
-  end
+    # Attach a failure callback
+    #
+    # @see Wisper
+    #
+    # @example
+    #   use_case = SignUp.new(params)
+    #   use_case.on_failure do
+    #     # handle failure
+    #   end
+    #   use_case.perform
+    #
+    # @since 0.0.1
+    # @api public
+    def on_failure(&block)
+      on(namespaced_name(:failure), &block)
+    end
 
-  private
+    private
 
-  # Mark the use case as successful and publish the event with
-  # Wisper.
-  #
-  # @return [TrueClass]
-  #
-  # @since 0.0.1
-  # @api public
-  def success(args = nil)
-    @failed = false
-    publish(namespaced_name(:success), args)
-    true
-  end
+    # Mark the use case as successful and publish the event with
+    # Wisper.
+    #
+    # @return [TrueClass]
+    #
+    # @since 0.0.1
+    # @api public
+    def success(args = nil)
+      @failed = false
+      publish(namespaced_name(:success), args)
+      true
+    end
 
-  # Mark the use case as failed and publish the event with
-  # Wisper.
-  #
-  # @return [FalseClass]
-  #
-  # @since 0.0.1
-  # @api public
-  def failure(args = nil)
-    @failed = true
-    publish(namespaced_name(:failure), args)
-    throw :halt
-  end
+    # Mark the use case as failed and publish the event with
+    # Wisper.
+    #
+    # @return [FalseClass]
+    #
+    # @since 0.0.1
+    # @api public
+    def failure(args = nil)
+      @failed = true
+      publish(namespaced_name(:failure), args)
+      throw :halt
+    end
 
-  # Return an event name namespaced by the underscored class name
-  #
-  # @return [String]
-  #
-  # @example
-  #   namespaced_event(:success)
-  #   # => "sign_up_success"
-  #   namespaced_event(:failure)
-  #   # => "sign_up_failure"
-  #
-  # @since 0.0.1
-  # @api private
-  def namespaced_name(event)
-    [model_name.param_key, event].join('_')
-  end
+    # Return an event name namespaced by the underscored class name
+    #
+    # @return [String]
+    #
+    # @example
+    #   namespaced_event(:success)
+    #   # => "sign_up_success"
+    #   namespaced_event(:failure)
+    #   # => "sign_up_failure"
+    #
+    # @since 0.0.1
+    # @api private
+    def namespaced_name(event)
+      [self.class.model_name.param_key, event].join('_')
+    end
 
-  # Halts execution of the use case if validation fails and
-  # published errors with Wisper.
-  #
-  # @since 0.0.1
-  # @api public
-  def validate!
-    failure(errors) unless valid?
-  end
+    # Halts execution of the use case if validation fails and
+    # published errors with Wisper.
+    #
+    # @since 0.0.1
+    # @api public
+    def validate!
+      failure(errors) unless valid?
+    end
 
-  # Indicates whether the use case called success or failure
-  #
-  # @return [TrueClass, FalseClass]
-  #
-  # @api private
-  # @since 0.0.1
-  def result_specified?
-    defined?(@failed)
+    # Indicates whether the use case called success or failure
+    #
+    # @return [TrueClass, FalseClass]
+    #
+    # @api private
+    # @since 0.0.1
+    def result_specified?
+      defined?(@failed)
+    end
   end
 end

--- a/lib/use_case.rb
+++ b/lib/use_case.rb
@@ -35,7 +35,7 @@ module UseCase
   # @since 0.0.1
   def self.use_case(options = {})
     validations = options.fetch(:validations, true)
-    ModuleCustomiser.new do
+    ModuleCustomiser.build do
       prepend Perform
       extend ClassMethods
       include InstanceMethods
@@ -59,7 +59,7 @@ module UseCase
   # @since 0.0.1
   def self.params(options = {})
     validations = options.fetch(:validations, true)
-    ModuleCustomiser.new do
+    ModuleCustomiser.build do
       include Params
       if validations
         include ActiveModel::Validations

--- a/lib/use_case.rb
+++ b/lib/use_case.rb
@@ -2,7 +2,7 @@ require "active_model"
 require "wisper"
 
 require "use_case/version"
-require "use_case/module_customiser"
+require "use_case/module_builder"
 require "use_case/validation_helpers"
 require "use_case/params"
 
@@ -35,7 +35,7 @@ module UseCase
   # @since 0.0.1
   def self.use_case(options = {})
     validations = options.fetch(:validations, true)
-    ModuleCustomiser.build do
+    ModuleBuilder.build do
       prepend Perform
       extend ClassMethods
       include InstanceMethods
@@ -59,7 +59,7 @@ module UseCase
   # @since 0.0.1
   def self.params(options = {})
     validations = options.fetch(:validations, true)
-    ModuleCustomiser.build do
+    ModuleBuilder.build do
       include Params
       if validations
         include ActiveModel::Validations

--- a/lib/use_case/module_builder.rb
+++ b/lib/use_case/module_builder.rb
@@ -3,12 +3,12 @@ module UseCase
   #
   # @example
   #   options = {}
-  #   ModuleCustomiser.build do
+  #   ModuleBuilder.build do
   #     if options.fetch(:validations, true)
   #       include ActiveSupport::Validations
   #     end
   #   end
-  class ModuleCustomiser
+  class ModuleBuilder
     def self.build(&block)
       Module.new.tap do |mod|
         mod.define_singleton_method(:included) do |base|

--- a/lib/use_case/module_customiser.rb
+++ b/lib/use_case/module_customiser.rb
@@ -3,18 +3,18 @@ module UseCase
   #
   # @example
   #   options = {}
-  #   ModuleCustomiser.new do
+  #   ModuleCustomiser.build do
   #     if options.fetch(:validations, true)
   #       include ActiveSupport::Validations
   #     end
   #   end
-  class ModuleCustomiser < Module
-    def initialize(&block)
-      @block = block
-    end
-
-    def included(base)
-      base.class_eval(&@block)
+  class ModuleCustomiser
+    def self.build(&block)
+      Module.new.tap do |mod|
+        mod.define_singleton_method(:included) do |base|
+          base.class_eval(&block)
+        end
+      end
     end
   end
 end

--- a/lib/use_case/module_customiser.rb
+++ b/lib/use_case/module_customiser.rb
@@ -1,0 +1,20 @@
+module UseCase
+  # Allows easy customisation of the included block.
+  #
+  # @example
+  #   options = {}
+  #   ModuleCustomiser.new do
+  #     if options.fetch(:validations, true)
+  #       include ActiveSupport::Validations
+  #     end
+  #   end
+  class ModuleCustomiser < Module
+    def initialize(&block)
+      @block = block
+    end
+
+    def included(base)
+      base.class_eval(&@block)
+    end
+  end
+end

--- a/lib/use_case/params.rb
+++ b/lib/use_case/params.rb
@@ -29,7 +29,6 @@ module UseCase
         extend AttributeOverride
 
         include ActiveModel::Conversion
-        include ActiveModel::Validations
       end
     end
 

--- a/spec/use_case/params_spec.rb
+++ b/spec/use_case/params_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe UseCase::Params do
   it 'defaults attributes to not required so that nil or the given type is an acceptable value' do
     params = Class.new do
-      include UseCase::Params
+      include UseCase.params
       attribute :name, String
     end.new
     expect(params.name).to be_nil
@@ -11,7 +11,7 @@ describe UseCase::Params do
 
   it 'allows required to be set to true' do
     params = Class.new do
-      include UseCase::Params
+      include UseCase.params
       attribute :name, String, required: true
     end
     expect { params.new }.to raise_error(Virtus::CoercionError)
@@ -19,7 +19,7 @@ describe UseCase::Params do
 
   it 'allows the active model name to be set' do
     params = Class.new do
-      include UseCase::Params
+      include UseCase.params
       attribute :name, String
       param_key(:user)
     end
@@ -29,7 +29,7 @@ describe UseCase::Params do
   context 'type coercion' do
     let(:klass) {
       Class.new do
-        include UseCase::Params
+        include UseCase.params
 
         attribute :name, String
       end
@@ -45,6 +45,32 @@ describe UseCase::Params do
       expect {
         klass.new
       }.not_to raise_error
+    end
+  end
+
+  describe 'configuration options' do
+    context 'without validations' do
+      let(:params_class) {
+        Class.new do
+          include UseCase.params(validations: false)
+        end
+      }
+
+      it "doesn't include ActiveModel::Validations" do
+        expect(params_class.ancestors).to_not include(ActiveModel::Validations)
+      end
+    end
+
+    context 'with validations' do
+      let(:params_class) {
+        Class.new do
+          include UseCase.params(validations: true)
+        end
+      }
+
+      it 'includes ActiveModel::Validations' do
+        expect(params_class.ancestors).to include(ActiveModel::Validations)
+      end
     end
   end
 end

--- a/spec/use_case_spec.rb
+++ b/spec/use_case_spec.rb
@@ -6,7 +6,7 @@ describe UseCase do
   describe '.perform' do
     let(:use_case_class) do
       Class.new do
-        include UseCase
+        include UseCase.use_case
         param_key 'sign_up'
 
         def initialize(*args)
@@ -60,7 +60,7 @@ describe UseCase do
   describe '#failure' do
     let(:use_case_class) {
       Class.new do
-        include UseCase
+        include UseCase.use_case
         param_key 'sign_up'
 
         def initialize(*args)
@@ -115,7 +115,7 @@ describe UseCase do
   describe '#success' do
     let(:use_case_class) {
       Class.new do
-        include UseCase
+        include UseCase.use_case
         param_key 'sign_up'
 
         def initialize(*args)
@@ -162,6 +162,31 @@ describe UseCase do
         expect(@args).to eq :my_arg
       end
     end
+  end
 
+  describe 'configuration options' do
+    context 'without validations' do
+      let(:use_case_class) {
+        Class.new do
+          include UseCase.use_case(validations: false)
+        end
+      }
+
+      it "doesn't include ActiveModel::Validations" do
+        expect(use_case_class.ancestors).to_not include(ActiveModel::Validations)
+      end
+    end
+
+    context 'with validations' do
+      let(:use_case_class) {
+        Class.new do
+          include UseCase.use_case(validations: true)
+        end
+      }
+
+      it 'includes ActiveModel::Validations' do
+        expect(use_case_class.ancestors).to include(ActiveModel::Validations)
+      end
+    end
   end
 end


### PR DESCRIPTION
Uses a module customiser to include AS Validations based on supplied options to `UseCase.use_case(validations: false)`.