### PR TITLE
Fix issue with validate! override from ActiveModel::Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Take a look at the [code itself](https://github.com/stevehodgkiss/interaction/bl
 ```ruby
 class SignUp
   include Interaction
-  include Interaction::ValidationHelpers
   include ActiveModel::Validations
+  include Interaction::ValidationHelpers
 
   # Virtus
   attribute :email, String

--- a/spec/interaction/validation_helpers_spec.rb
+++ b/spec/interaction/validation_helpers_spec.rb
@@ -5,8 +5,8 @@ describe Interaction::ValidationHelpers do
   subject(:use_case) {
     Class.new {
       include Interaction
-      include Interaction::ValidationHelpers
       include ActiveModel::Validations
+      include Interaction::ValidationHelpers
 
       def self.model_name
         ActiveModel::Name.new(self, nil, "Test")


### PR DESCRIPTION
ActiveModel::Validation introduced a `validate!` method in version 4.2.1 and has been a part of it since.

This causes issues with the examples in the README and specs for the gem as ActiveModel::Validation is included after the ValidationHelpers.